### PR TITLE
[Feature] 헤더 컴포넌트의 관리자 버전 추가

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -21,7 +21,8 @@ function Header() {
         </Link>
       </div>
       <div className={style.headerRight}>
-        {user ? (
+        {user && user.role === 'ADMIN' && <span className={style.adminBadge}>관리자</span>}
+        {user && user.role === 'USER' && (
           <>
             <Link to="/cart" className={style.cartBtn}>
               장바구니
@@ -29,8 +30,10 @@ function Header() {
             <Link to="/mypage" className={style.myPageBtn}>
               마이페이지
             </Link>
-            <LogoutButton />
           </>
+        )}
+        {user ? (
+          <LogoutButton />
         ) : (
           <>
             <Link to="/signin" className={style.loginBtn}>

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -45,6 +45,14 @@
   border: none;
 }
 
+.adminBadge {
+  background: #222;
+  color: #fff;
+  font-size: 12px;
+  border-radius: 10px;
+  padding: 10px 15px;
+}
+
 @media (max-width: 712px) {
   .headerLogo {
     display: none;

--- a/src/components/Header/Header.module.css
+++ b/src/components/Header/Header.module.css
@@ -11,6 +11,7 @@
   top: 0;
   left: 0;
   z-index: 1000;
+  border-bottom: 1px solid #858585;
 }
 
 .headerLeft {

--- a/src/pages/SignIn.module.css
+++ b/src/pages/SignIn.module.css
@@ -5,10 +5,11 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding-top: 27px;
 }
 
 .signinSection {
-  width: 600px;
+  width: 400px;
   background: #fff;
   border-radius: 20px;
   box-shadow: 0 4px 24px rgba(38, 38, 38, 0.249);
@@ -19,14 +20,15 @@
 }
 
 .signinTitle {
-  font-weight: 700;
-  font-size: 22px;
+  font-weight: 600;
+  font-size: 20px;
   margin: 0;
+  padding: 0;
 }
 
 .signinDesc {
   font-weight: 400;
-  font-size: 15px;
+  font-size: 13px;
   color: #858585;
   margin: 5px 0 20px 0;
 }
@@ -34,12 +36,12 @@
 .signinForm {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 12px;
 }
 
 .signinLabel {
   font-weight: 500;
-  font-size: 18px;
+  font-size: 15px;
 }
 
 .signinInput {
@@ -47,7 +49,7 @@
   box-sizing: border-box;
   margin: 8px 0;
   padding: 15px 20px;
-  font-size: 15px;
+  font-size: 13px;
   border: 1px solid #858585;
   border-radius: 10px;
   outline: none;

--- a/src/pages/SignUp.jsx
+++ b/src/pages/SignUp.jsx
@@ -254,13 +254,13 @@ function SignUp() {
             )}
             {/* 이용약관 동의 체크박스 */}
             <div className={styles.signupTermsRow}>
-              <label htmlFor="agree-terms" style={{ fontWeight: 500, fontSize: 16 }}>
+              <label htmlFor="agree-terms" className={styles.agreeTerms}>
                 <input
                   id="agree-terms"
                   type="checkbox"
                   {...register('agreeTerms')} // eslint-disable-line react/jsx-props-no-spreading
                   required
-                  style={{ marginRight: 8 }}
+                  className={styles.agreeTermsCheckbox}
                 />
                 이용약관에 동의합니다(필수)
               </label>

--- a/src/pages/SignUp.module.css
+++ b/src/pages/SignUp.module.css
@@ -5,10 +5,11 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  padding-top: 27px;
 }
 
 .signupSection {
-  width: 600px;
+  width: 400px;
   background: #fff;
   border-radius: 20px;
   box-shadow: 0 4px 24px rgba(0, 0, 0, 0.06);
@@ -19,14 +20,15 @@
 }
 
 .signupTitle {
-  font-weight: 700;
-  font-size: 22px;
+  font-weight: 600;
+  font-size: 20px;
   margin: 0;
+  padding: 0;
 }
 
 .signupDesc {
   font-weight: 400;
-  font-size: 15px;
+  font-size: 13px;
   color: #858585;
   margin: 5px 0 20px 0;
 }
@@ -34,12 +36,12 @@
 .signupForm {
   display: flex;
   flex-direction: column;
-  gap: 15px;
+  gap: 12px;
 }
 
 .signupLabel {
   font-weight: 500;
-  font-size: 18px;
+  font-size: 15px;
 }
 
 .signupInput {
@@ -47,7 +49,7 @@
   box-sizing: border-box;
   margin: 8px 0;
   padding: 15px 20px;
-  font-size: 15px;
+  font-size: 13px;
   border: 1px solid #858585;
   border-radius: 10px;
   outline: none;
@@ -76,8 +78,9 @@
 }
 
 .signupTestBtn {
-  width: 150px;
-  padding: 17px;
+  font-size: 13px;
+  width: 130px;
+  padding: 16px;
   background: #e5e5e5;
   border: none;
   border-radius: 10px;
@@ -96,6 +99,20 @@
 .signupError {
   color: red;
   margin-top: 10px;
+}
+
+.agreeTerms {
+  font-weight: 500;
+  font-size: 13px;
+  color: #000;
+  cursor: pointer;
+}
+
+.agreeTermsCheckbox {
+  margin-right: 8px;
+  width: 16px;
+  height: 16px;
+  vertical-align: middle;
 }
 
 .signupLinks {

--- a/src/states/authStore.js
+++ b/src/states/authStore.js
@@ -8,13 +8,32 @@ const MOCK_USER = {
   password: '1234',
 };
 
+const MOCK_ADMIN = {
+  email: 'admin@e.com',
+  password: '1234',
+};
+
 const MOCK_USER_RESPONSE = {
   id: 1,
   username: '홍길동',
   nickname: '불타는 수박1',
-  email: 'test@example.com',
+  email: 'e@e.com',
   phoneNumber: '01012345678',
   role: 'USER',
+  status: 'active',
+  grade: 'VIP',
+  last_login_at: '2024-12-01T10:30:00',
+  createdAt: '2024-12-01T10:30:00',
+  updatedAt: null,
+};
+
+const MOCK_ADMIN_RESPONSE = {
+  id: 0,
+  username: '관리자',
+  nickname: '나는야 관리자',
+  email: 'admin@e.com',
+  phoneNumber: '01012345678',
+  role: 'ADMIN',
   status: 'active',
   grade: 'VIP',
   last_login_at: '2024-12-01T10:30:00',
@@ -31,6 +50,10 @@ const useAuthStore = create(
         // mock 유저로 테스트
         if (email === MOCK_USER.email && password === MOCK_USER.password) {
           set({ user: MOCK_USER_RESPONSE });
+          return true;
+        }
+        if (email === MOCK_ADMIN.email && password === MOCK_ADMIN.password) {
+          set({ user: MOCK_ADMIN_RESPONSE });
           return true;
         }
         return false;


### PR DESCRIPTION
## 📌 작업 내용 요약

ADMIN 페이지에 렌더링 되는 헤더 UI를 추가했습니다.
- user의 권한이 ADMIN인 경우, 관리자 배지를 표시합니다.
- 이를 테스트하기 위해 authStore에 mock admin 계정을 추가했습니다.
- 아이디 admin@e.com 패스워드 1234

사소한 스타일 수정
- 헤더 컴포넌트 하단에 얇은 구분선을 추가했습니다.
- 로그인과 회원가입 페이지 UI 소폭 변경했습니다.
  - 크기를 전체적으로 축소했습니다.
  - padding-top을 추가해 상단으로부터의 위치를 아래로 옮겼습니다.

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Related to #16 
- Related to #17 
- Related to #18 