### PR TITLE
[Feature] 주문 내역 상세 보기 모달 UI

### DIFF
--- a/src/modals/OrderInfoModal/OrderInfoModal.jsx
+++ b/src/modals/OrderInfoModal/OrderInfoModal.jsx
@@ -99,13 +99,14 @@ function OrderInfoModal({ isOpen, onClose, orderId }) {
   };
 
   return (
-    <button
-      type="button"
-      className={styles.overlay}
-      onClick={handleOverlayClick}
-      aria-label="모달 닫기"
-    >
-      <div className={styles.modal} role="dialog" aria-modal="true" aria-labelledby="modal-title">
+    <div className={styles.overlay} onClick={handleOverlayClick} role="presentation">
+      <div
+        className={styles.modal}
+        role="dialog"
+        id="order-info-modal"
+        aria-modal="true"
+        aria-labelledby="order-info-modal-title"
+      >
         {/* 닫기 버튼 */}
         <button
           type="button"
@@ -213,7 +214,7 @@ function OrderInfoModal({ isOpen, onClose, orderId }) {
           )}
         </div>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/src/modals/OrderInfoModal/OrderInfoModal.jsx
+++ b/src/modals/OrderInfoModal/OrderInfoModal.jsx
@@ -1,0 +1,226 @@
+import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+
+import styles from './OrderInfoModal.module.css';
+
+const response = {
+  status: 200,
+  message: '주문 상세 조회 성공',
+  data: {
+    orderId: 4,
+    orderNumber: '20250625-000004',
+    orderedAt: '2025-06-25T15:00:00',
+    userName: '홍길동',
+    shippingAddress: {
+      recipient: '홍길동',
+      phone: '010-1234-5678',
+      zipcode: '06236',
+      address1: '서울 강남구 테헤란로 123',
+      address2: '101동 1001호',
+    },
+    orderStatus: 'COMPLETED',
+    paymentMethod: 'CHEETOS',
+    totalAmount: 1097000,
+    orderItems: [
+      {
+        productName: '머찐의자',
+        option: '빨간색',
+        quantity: 2,
+        price: 399000,
+        totalPrice: 798000,
+      },
+      {
+        productName: '귀여운책상',
+        option: '파란색',
+        quantity: 1,
+        price: 299000,
+        totalPrice: 299000,
+      },
+    ],
+    totalCount: 3,
+  },
+};
+
+function OrderInfoModal({ isOpen, onClose, orderId }) {
+  const [orderData, setOrderData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const handleEscape = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+
+    return undefined;
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
+    if (isOpen && orderId) {
+      const fetchOrderData = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+          // const response = await fetch(`/api/users/me/orders/${orderId}`);
+          // if (!response.ok) {
+          //   throw new Error('주문 정보를 불러오는데 실패했습니다.');
+          // }
+          // const data = await response.json();
+
+          // 실제 API 호출 대신 하드코딩된 response 사용
+          setOrderData(response.data);
+        } catch (err) {
+          setError(err.message);
+        } finally {
+          setLoading(false);
+        }
+      };
+
+      fetchOrderData();
+    }
+  }, [isOpen, orderId]);
+
+  if (!isOpen) return null;
+
+  const handleOverlayClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const handleOrderCancel = () => {
+    // 주문 취소
+  };
+
+  return (
+    <button
+      type="button"
+      className={styles.overlay}
+      onClick={handleOverlayClick}
+      aria-label="모달 닫기"
+    >
+      <div className={styles.modal} role="dialog" aria-modal="true" aria-labelledby="modal-title">
+        {/* 닫기 버튼 */}
+        <button
+          type="button"
+          className={styles.closeButton}
+          onClick={onClose}
+          aria-label="모달 닫기"
+        >
+          <svg className={styles.closeIcon} viewBox="0 0 24 24" fill="none">
+            <path
+              d="M18 6L6 18M6 6L18 18"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </button>
+
+        {/* 모달 콘텐츠 */}
+        <div className={styles.content}>
+          {loading && (
+            <div className={styles.loading}>
+              <p>주문 정보를 불러오는 중...</p>
+            </div>
+          )}
+
+          {error && (
+            <div className={styles.error}>
+              <p>{error}</p>
+            </div>
+          )}
+
+          {orderData && (
+            <>
+              <div className={styles.orderInfo}>
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>주문 일자</span>
+                  <span className={styles.value}>
+                    {orderData.orderedAt
+                      ? new Date(orderData.orderedAt).toLocaleDateString('ko-KR')
+                      : '2025.06.17'}
+                  </span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>주문 번호</span>
+                  <span className={styles.value}>{orderData.orderNumber || '2025061703'}</span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>구매자</span>
+                  <span className={styles.value}>{orderData.userName || '김구름'}</span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>배송지</span>
+                  <span className={styles.value}>
+                    {orderData.shippingAddress
+                      ? `${orderData.shippingAddress.address1} ${orderData.shippingAddress.address2 || ''}`.trim()
+                      : '경기도 성남시 분당구 판교로 242 PDC A동 9층'}
+                  </span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>주문 상품</span>
+                  <span className={styles.value}>
+                    {/* eslint-disable indent */}
+                    {orderData.orderItems && orderData.orderItems.length > 0
+                      ? orderData.orderItems
+                          .map((item) => `${item.productName} ${item.quantity}개`)
+                          .join(', ')
+                      : '머찐 의자 2개'}
+                    {/* eslint-enable indent */}
+                  </span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>총 결제 금액</span>
+                  <span className={styles.value}>
+                    {orderData.totalAmount?.toLocaleString() || '64,000'}
+                  </span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>결제 수단</span>
+                  <span className={styles.value}>{orderData.paymentMethod || '치토스'}</span>
+                </div>
+
+                <div className={styles.infoRow}>
+                  <span className={styles.label}>주문 상태</span>
+                  <span className={styles.value}>
+                    {orderData.orderStatus === 'COMPLETED'
+                      ? '결제 완료'
+                      : orderData.orderStatus || '결제 완료'}
+                  </span>
+                </div>
+              </div>
+
+              {/* 주문 취소 버튼 */}
+              <div className={styles.buttonContainer}>
+                <button type="button" className={styles.cancelButton} onClick={handleOrderCancel}>
+                  주문 취소
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+OrderInfoModal.propTypes = {
+  isOpen: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+  orderId: PropTypes.string.isRequired,
+};
+
+export default OrderInfoModal;

--- a/src/modals/OrderInfoModal/OrderInfoModal.module.css
+++ b/src/modals/OrderInfoModal/OrderInfoModal.module.css
@@ -1,0 +1,173 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(250, 250, 250, 0.854);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  border: none;
+  padding: 0;
+  cursor: default;
+}
+
+.modal {
+  position: relative;
+  width: 450px;
+  max-height: 90vh;
+  background-color: #f2f2f2;
+  border: rgb(211, 211, 211) solid 1px;
+  border-radius: 10px;
+  padding: 50px 40px 30px 40px;
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
+.closeButton {
+  position: absolute;
+  top: 23px;
+  right: 35px;
+  width: 15px;
+  height: 15px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+}
+
+.closeIcon {
+  width: 15px;
+  height: 15px;
+  stroke: #1e1e1e;
+  stroke-width: 4px;
+}
+
+.content {
+  width: 100%;
+}
+
+/* 로딩 및 에러 상태 */
+.loading,
+.error {
+  text-align: center;
+  padding: 60px 20px;
+}
+
+.loading p {
+  font-size: 15px;
+  color: #666;
+}
+
+.error p {
+  font-size: 15px;
+  color: #dc3545;
+}
+
+.orderInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.infoRow {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.label {
+  font-weight: 600;
+  font-size: 18px;
+  color: #000000;
+  text-align: left;
+}
+
+.value {
+  font-weight: 400;
+  font-size: 15px;
+  color: #000000;
+  text-align: left;
+}
+
+.buttonContainer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 30px;
+}
+
+.cancelButton {
+  width: 100px;
+  height: 40px;
+  background-color: #9f9f9f;
+  border: none;
+  border-radius: 10px;
+  font-weight: 500;
+  font-size: 13px;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.cancelButton:hover {
+  background-color: #8a8a8a;
+}
+
+.cancelButton:active {
+  background-color: #757575;
+}
+
+@media (max-width: 712px) {
+  .modal {
+    width: 90%;
+    max-width: 600px;
+    margin: 20px;
+    padding: 40px 20px 20px;
+  }
+
+  .label,
+  .value {
+    font-size: 18px;
+  }
+
+  .cancelButton {
+    width: 150px;
+    height: 70px;
+    font-size: 16px;
+  }
+
+  .orderInfo {
+    gap: 25px;
+  }
+}
+
+@media (max-width: 480px) {
+  .modal {
+    width: 95%;
+    padding: 30px 15px 15px;
+  }
+
+  .label,
+  .value {
+    font-size: 16px;
+  }
+
+  .cancelButton {
+    width: 130px;
+    height: 60px;
+    font-size: 14px;
+  }
+
+  .orderInfo {
+    gap: 20px;
+  }
+
+  .buttonContainer {
+    margin-top: 30px;
+  }
+}


### PR DESCRIPTION
## 📌 작업 내용 요약

- 마이페이지 > 내 주문 내역 중에서 하나의 주문 내역의 상세 정보를 확인할 수 있는 모달의 UI를 구현했습니다.
- props로 orderId를 받고 있습니다.
  - 현재는 아무 값이나 넣어 주시면 하드코딩된 값으로 주문 내역을 렌더링하고 있습니다.
  - API 연동 예정입니다.

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #43 

---

## 📎 기타 참고 사항

추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.