### PR TITLE
[Feature] 이메일 중복 확인 API 연동 및 에러 메시지 처리 추가

### DIFF
--- a/src/features/auth/components/SignUpForm/SignUpForm.jsx
+++ b/src/features/auth/components/SignUpForm/SignUpForm.jsx
@@ -58,28 +58,42 @@ function SignUpForm({ onSubmit }) {
   const handleCheckEmail = async () => {
     const email = watch('email');
 
-    if (errors.email) {
-      setEmailChecked(false);
-      setEmailCheckMsg('');
-      return;
-    }
-
-    if (!email) {
+    // 이메일이 입력되지 않은 경우
+    if (!email || !email.trim()) {
       setError('email', { message: '이메일을 입력해 주세요.' });
       setEmailChecked(false);
       setEmailCheckMsg('');
       return;
     }
 
+    // 이메일 형식 검증 오류가 있는 경우
+    if (errors.email) {
+      setEmailChecked(false);
+      setEmailCheckMsg('');
+      return;
+    }
+
+    // API 요청 전 상태 초기화
+    setEmailChecked(false);
+    setEmailCheckMsg('');
+    setError('email', {});
+
     // API 요청
     try {
-      await checkEmailDuplicate(email); // 중복 아니면 200 응답
+      const result = await checkEmailDuplicate(email.trim());
+      // checkEmailDuplicate가 true/false를 반환하는 경우도 방어
+      if (result === false) {
+        setEmailChecked(false);
+        setEmailCheckMsg('이미 사용 중인 이메일입니다.');
+        return;
+      }
       setEmailChecked(true);
       setEmailCheckMsg('사용 가능한 이메일입니다.');
     } catch (errMsg) {
       setEmailChecked(false);
-      setEmailCheckMsg(errMsg);
-      setError('email', { message: errMsg });
+      setEmailCheckMsg(
+        typeof errMsg === 'string' && errMsg ? errMsg : '이미 사용 중인 이메일입니다.',
+      );
     }
   };
 
@@ -132,9 +146,15 @@ function SignUpForm({ onSubmit }) {
             {...register('email')} // eslint-disable-line react/jsx-props-no-spreading
             required
             style={{ flex: 1 }}
+            disabled={emailChecked}
             onChange={() => {
+              // 이메일이 변경되면 중복 확인 상태 초기화
               setEmailChecked(false);
               setEmailCheckMsg('');
+              // 기존 API 에러 메시지도 클리어
+              if (emailCheckMsg && !emailChecked) {
+                setError('email', {});
+              }
             }}
           />
           <button

--- a/src/features/auth/components/SignUpForm/SignUpForm.jsx
+++ b/src/features/auth/components/SignUpForm/SignUpForm.jsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { signUpSchema } from '@/features/auth/schemas/signUpSchema';
+import useAuthStore from '@/states/authStore';
 
 import styles from './SignUpForm.module.css';
 
@@ -53,15 +54,33 @@ function SignUpForm({ onSubmit }) {
   };
 
   // 이메일 중복 확인
+  const checkEmailDuplicate = useAuthStore((state) => state.checkEmailDuplicate);
   const handleCheckEmail = async () => {
-    if (!watch('email')) {
+    const email = watch('email');
+
+    if (errors.email) {
+      setEmailChecked(false);
+      setEmailCheckMsg('');
+      return;
+    }
+
+    if (!email) {
       setError('email', { message: '이메일을 입력해 주세요.' });
       setEmailChecked(false);
       setEmailCheckMsg('');
       return;
     }
-    setEmailChecked(true);
-    setEmailCheckMsg('사용 가능한 이메일입니다.');
+
+    // API 요청
+    try {
+      await checkEmailDuplicate(email); // 중복 아니면 200 응답
+      setEmailChecked(true);
+      setEmailCheckMsg('사용 가능한 이메일입니다.');
+    } catch (errMsg) {
+      setEmailChecked(false);
+      setEmailCheckMsg(errMsg);
+      setError('email', { message: errMsg });
+    }
   };
 
   const handleFormSubmit = async (data) => {
@@ -113,6 +132,10 @@ function SignUpForm({ onSubmit }) {
             {...register('email')} // eslint-disable-line react/jsx-props-no-spreading
             required
             style={{ flex: 1 }}
+            onChange={() => {
+              setEmailChecked(false);
+              setEmailCheckMsg('');
+            }}
           />
           <button
             type="button"

--- a/src/states/authStore.js
+++ b/src/states/authStore.js
@@ -29,6 +29,17 @@ const useAuthStore = create(
         }
       },
 
+      checkEmailDuplicate: async (email) => {
+        try {
+          const response = await axiosInstance.get('/api/users/check-email', {
+            params: { email },
+          });
+          return response.data;
+        } catch (e) {
+          return false;
+        }
+      },
+
       logout: () => {
         // localStorage에서 토큰 삭제
         localStorage.removeItem('accessToken');


### PR DESCRIPTION
## 🔀 PR 제목

- [Fix] 이메일 중복 확인 API 연동 및 에러 메시지 처리 추가
---

## 📌 작업 내용 요약

- 이메일 중복 확인 API (GET /api/users/check-email) 연동
- 중복 여부에 따라 에러 메시지 표시 및 중복 확인 버튼 처리
- 이메일 형식 오류가 있을 경우 API 호출하지 않도록 코드 추가

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #89

---

## 📎 기타 참고 사항

- 이메일 입력 시 중복 확인 상태 초기화되도록 처리
- checkEmailDuplicate API 에러 응답 메시지를 사용자에게 보여줌
- 유효하지 않은 이메일 형식 입력 시 API 요청 방지
