### PR TITLE
[Feature] 관리자 주문 상세 보기 API 연결 + 프로필 이미지 링크 수정

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -27,7 +27,11 @@ function Header() {
           <div className={style.userDropdown}>
             <div className={style.userProfile}>
               <span className={style.userNickname}>{user.nickname} 님</span>
-              <img src={userImage} alt="사용자 프로필" className={style.userImage} />
+              <img
+                src={user.imagePath || userImage}
+                alt="사용자 프로필"
+                className={style.userImage}
+              />
             </div>
             <div className={style.dropdownMenu}>
               <div className={style.userInfo}>

--- a/src/modals/AdminOrderInfoModal/AdminOrderInfoModal.jsx
+++ b/src/modals/AdminOrderInfoModal/AdminOrderInfoModal.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
 
 import { fetchOrderDetail } from '@/services/adminOrderApi';
+import axiosInstance from '@/services/axiosInstance';
 
 import styles from './AdminOrderInfoModal.module.css';
 
@@ -17,10 +18,13 @@ function getOrderStatusText(status) {
   return ORDER_STATUS_MAP[status] || status;
 }
 
+const STATUS_SEQUENCE = ['PAYMENT_COMPLETED', 'CREATED', 'SHIPPING', 'COMPLETED'];
+
 function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
   const [orderData, setOrderData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [manualStatus, setManualStatus] = useState('PAYMENT_COMPLETED');
 
   useEffect(() => {
     const handleEscape = (e) => {
@@ -46,7 +50,7 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
           const data = await fetchOrderDetail(orderId);
           setOrderData(data);
         } catch (err) {
-          setError(err.message);
+          setError(err.response?.data?.message || '주문 정보를 불러오는데 실패했습니다.');
         } finally {
           setLoading(false);
         }
@@ -64,8 +68,48 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
     }
   };
 
-  const handleOrderCancel = () => {
-    // 주문 취소
+  const handleOrderCancel = async () => {
+    if (!orderData || orderData.orderStatus === 'CANCELED' || orderData.orderStatus === 'COMPLETED')
+      return;
+    // eslint-disable-next-line no-restricted-globals, no-alert
+    const confirmed = confirm('정말로 주문을 취소하시겠습니까?');
+    if (!confirmed) return;
+    try {
+      setLoading(true);
+      await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, { status: 'CANCELED' });
+      setOrderData((prev) => ({ ...prev, orderStatus: 'CANCELED' }));
+    } catch (err) {
+      setError(err.response?.data?.message || '주문 취소에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStatusChange = async () => {
+    if (!orderData) return;
+    let message = '정말로 배송 상태를 변경하시겠습니까?';
+    if (orderData.orderStatus === 'PAYMENT_COMPLETED') {
+      message = '배송 준비 중 상태로 변경하시겠습니까?';
+    } else if (orderData.orderStatus === 'CREATED') {
+      message = '배송 중 상태로 변경하시겠습니까?';
+    } else if (orderData.orderStatus === 'SHIPPING') {
+      message = '배송 완료 상태로 변경하시겠습니까?';
+    }
+    // eslint-disable-next-line no-restricted-globals, no-alert
+    const confirmed = confirm(message);
+    if (!confirmed) return;
+    const currentIdx = STATUS_SEQUENCE.indexOf(orderData.orderStatus);
+    if (currentIdx === -1 || currentIdx === STATUS_SEQUENCE.length - 1) return;
+    const nextStatus = STATUS_SEQUENCE[currentIdx + 1];
+    try {
+      setLoading(true);
+      await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, { status: nextStatus });
+      setOrderData((prev) => ({ ...prev, orderStatus: nextStatus }));
+    } catch (err) {
+      setError(err.response?.data?.message || '배송 상태 변경에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -160,14 +204,92 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
                 </div>
               </div>
 
+              {/* 상태 수동 변경하는 테스트용 드롭다운 입니당 추후 삭제 예정 */}
+              <div className={`${styles.testButtonContainer} ${styles.buttonContainer}`}>
+                <select
+                  value={manualStatus}
+                  onChange={(e) => setManualStatus(e.target.value)}
+                  style={{ marginRight: 8, padding: '4px 8px', borderRadius: 4 }}
+                  disabled={loading}
+                >
+                  {Object.keys(ORDER_STATUS_MAP).map((status) => (
+                    <option key={status} value={status}>
+                      {ORDER_STATUS_MAP[status]}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  style={{
+                    fontSize: '12px',
+                    padding: '4px 8px',
+                    borderRadius: 4,
+                    backgroundColor: '#cfcfcf',
+                  }}
+                  onClick={async () => {
+                    if (!orderData) return;
+                    // eslint-disable-next-line no-restricted-globals, no-alert
+                    const confirmed = confirm(
+                      `${ORDER_STATUS_MAP[manualStatus]} 상태로 직접 변경하시겠습니까?`,
+                    );
+                    if (!confirmed) return;
+                    try {
+                      setLoading(true);
+                      await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, {
+                        status: manualStatus,
+                      });
+                      setOrderData((prev) => ({ ...prev, orderStatus: manualStatus }));
+                    } catch (err) {
+                      setError(err.response?.data?.message || '상태 변경에 실패했습니다.');
+                    } finally {
+                      setLoading(false);
+                    }
+                  }}
+                  disabled={loading}
+                >
+                  상태 직접 변경
+                </button>
+              </div>
+              {/* 테스트 드롭다운 끝! */}
+
               {/* 주문 수정 버튼 */}
               <div className={styles.buttonContainer}>
-                <button type="button" className={styles.updateButton}>
-                  배송 상태 변경
-                </button>
-                <button type="button" className={styles.cancelButton} onClick={handleOrderCancel}>
-                  주문 취소
-                </button>
+                {orderData.orderStatus !== 'CANCELED' && orderData.orderStatus !== 'COMPLETED' && (
+                  <button
+                    type="button"
+                    className={styles.updateButton}
+                    onClick={handleStatusChange}
+                  >
+                    배송 상태 변경
+                  </button>
+                )}
+                {(() => {
+                  let cancelBtnText = '주문 취소';
+                  let cancelBtnDisabled = false;
+                  let cancelBtnOnClick = handleOrderCancel;
+                  if (orderData.orderStatus === 'CANCELED') {
+                    cancelBtnText = '주문 취소 완료';
+                    cancelBtnDisabled = true;
+                    cancelBtnOnClick = undefined;
+                  } else if (
+                    orderData.orderStatus === 'COMPLETED' ||
+                    orderData.orderStatus === 'SHIPPING'
+                  ) {
+                    cancelBtnText = '주문 취소 불가';
+                    cancelBtnDisabled = true;
+                    cancelBtnOnClick = undefined;
+                  }
+                  return (
+                    <button
+                      type="button"
+                      className={styles.cancelButton}
+                      onClick={cancelBtnOnClick}
+                      disabled={cancelBtnDisabled}
+                    >
+                      {cancelBtnText}
+                    </button>
+                  );
+                })()}
               </div>
             </>
           )}


### PR DESCRIPTION
## 📌 작업 내용 요약

- 관리자 주문 상세 보기 모달의 [배송 상태 변경] 버튼과 [주문 취소] 버튼의 기능을 API 연동했습니다.
- 기존 src/asset에서 끌어다 쓰던 프로필 이미지를 User의 imagePath로 변경했습니다.

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #87 
- Closes #88 