### PR TITLE
[Refactor] 회원가입 validation 로직 및 스키마 검증 추가

### DIFF
--- a/src/features/auth/components/SignUpForm/SignUpForm.jsx
+++ b/src/features/auth/components/SignUpForm/SignUpForm.jsx
@@ -36,8 +36,13 @@ function SignUpForm({ onSubmit }) {
 
   // 인증번호 발송
   const handleSendAuth = () => {
-    if (!watch('phone')) {
+    const phone = watch('phone');
+    if (!phone) {
       setError('phone', { message: '휴대폰 번호를 입력해 주세요.' });
+      return;
+    }
+    if (!/^010\d{8}$/.test(phone)) {
+      setError('phone', { message: '휴대폰 번호는 010으로 시작하는 11자리 숫자여야 합니다.' });
       return;
     }
     setIsAuthSent(true);

--- a/src/features/auth/components/SignUpForm/SignUpForm.jsx
+++ b/src/features/auth/components/SignUpForm/SignUpForm.jsx
@@ -25,7 +25,7 @@ function SignUpForm({ onSubmit }) {
     resolver: zodResolver(signUpSchema),
     mode: 'onBlur',
     defaultValues: {
-      nickname: '',
+      username: '',
       email: '',
       password: '',
       passwordCheck: '',
@@ -120,18 +120,18 @@ function SignUpForm({ onSubmit }) {
   return (
     <form className={styles.signupForm} onSubmit={handleSubmit(handleFormSubmit)}>
       {/* 실명 입력 */}
-      <label htmlFor="signup-nickname" className={styles.signupLabel}>
+      <label htmlFor="signup-username" className={styles.signupLabel}>
         이름
         <input
-          id="signup-nickname"
+          id="signup-username"
           type="text"
           placeholder="사용자 찾기에 사용됩니다."
           className={styles.signupInput}
-          {...register('nickname')} // eslint-disable-line react/jsx-props-no-spreading
+          {...register('username')} // eslint-disable-line react/jsx-props-no-spreading
           required
         />
-        {errors.nickname && (
-          <div style={{ color: 'red', fontSize: 14 }}>{errors.nickname.message}</div>
+        {errors.username && (
+          <div style={{ color: 'red', fontSize: 14 }}>{errors.username.message}</div>
         )}
       </label>
       {/* 이메일 및 중복 확인 */}

--- a/src/features/auth/pages/SignUp/SignUp.jsx
+++ b/src/features/auth/pages/SignUp/SignUp.jsx
@@ -15,7 +15,7 @@ function SignUp() {
       email: data.email,
       password: data.password,
       passwordCheck: data.passwordCheck,
-      username: data.nickname,
+      username: data.username,
       phoneNumber: data.phone,
       address: '서울특별시 강남구 테헤란로 123',
     };

--- a/src/features/auth/schemas/signUpSchema.js
+++ b/src/features/auth/schemas/signUpSchema.js
@@ -20,7 +20,7 @@ export const signUpSchema = z.object({
       /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/,
       '비밀번호는 영어 소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
     ),
-  phone: z.string().min(10, '휴대폰 번호를 올바르게 입력해 주세요.'),
+  phone: z.string().regex(/^010\d{8}$/, '휴대폰 번호는 010으로 시작하는 11자리 숫자여야 합니다.'),
   agreeTerms: z.literal(true, { errorMap: () => ({ message: '이용약관에 동의해 주세요.' }) }),
 });
 

--- a/src/features/auth/schemas/signUpSchema.js
+++ b/src/features/auth/schemas/signUpSchema.js
@@ -1,10 +1,25 @@
 import { z } from 'zod';
 
 export const signUpSchema = z.object({
-  nickname: z.string().min(2, '이름은 2자 이상 입력해 주세요.'),
+  username: z
+    .string()
+    .min(2, '이름은 2자 이상 입력해 주세요.')
+    .regex(/^[가-힣]{2,}$/, '이름은 한글 2자 이상만 입력 가능합니다.'),
   email: z.string().email('올바른 이메일 형식이 아닙니다.'),
-  password: z.string().min(4, '비밀번호는 4자 이상이어야 합니다.'),
-  passwordCheck: z.string().min(4, '비밀번호 확인은 4자 이상이어야 합니다.'),
+  password: z
+    .string()
+    .min(8, '비밀번호는 8자 이상이어야 합니다.')
+    .regex(
+      /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/,
+      '비밀번호는 영어 소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
+    ),
+  passwordCheck: z
+    .string()
+    .min(8, '비밀번호 확인은 8자 이상이어야 합니다.')
+    .regex(
+      /^(?=.*[a-z])(?=.*\d)(?=.*[!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]).{8,}$/,
+      '비밀번호는 영어 소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
+    ),
   phone: z.string().min(10, '휴대폰 번호를 올바르게 입력해 주세요.'),
   agreeTerms: z.literal(true, { errorMap: () => ({ message: '이용약관에 동의해 주세요.' }) }),
 });


### PR DESCRIPTION
## 📌 작업 내용 요약

- 회원가입 시 유저의 정보를 검증하는 로직을 강화했습니다.
- 기존
  - username: 2자 이상
  - password: 4자 이상
  - phone: 숫자 외 검증 조건 따로 없음
- 수정 후
  - username: 한글로만 2자 이상
  - password: 소문자 + 숫자 + 특수문자 3가지 조합으로 8자 이상
  - phone: 010으로 시작하는 11자리 숫자(010-xxxx-xxxx)

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #100
- Closes #102 