### PR TITLE
[Fix] 관리자 페이지 일부 수정 및 토스트 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-icons": "^5.5.0",
     "react-is": "^19.1.0",
     "react-router-dom": "^7.6.2",
+    "react-toastify": "^11.0.5",
     "recharts": "^3.0.2",
     "swiper": "^11.2.10",
     "zod": "^3.25.67",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,8 @@
 import './App.css';
+import 'react-toastify/dist/ReactToastify.css';
 
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
+import { ToastContainer } from 'react-toastify';
 
 import AdminPage from '@/pages/AdminPage';
 import MainPage from '@/pages/MainPage';
@@ -12,16 +14,29 @@ import OrderPage from './pages/OrderPage';
 
 function App() {
   return (
-    <Router>
-      <Routes>
-        <Route path="/*" element={<MainPage />} />
-        <Route path="auth/*" element={<AuthPage />} />
-        <Route path="admin/*" element={<AdminPage />} />
-        <Route path="mypage/*" element={<MyPage />} />
-        <Route path="order/*" element={<OrderPage />} />
-        <Route path="cart/*" element={<CartPage />} />
-      </Routes>
-    </Router>
+    <>
+      <Router>
+        <Routes>
+          <Route path="/*" element={<MainPage />} />
+          <Route path="auth/*" element={<AuthPage />} />
+          <Route path="admin/*" element={<AdminPage />} />
+          <Route path="mypage/*" element={<MyPage />} />
+          <Route path="order/*" element={<OrderPage />} />
+          <Route path="cart/*" element={<CartPage />} />
+        </Routes>
+      </Router>
+      <ToastContainer
+        position="top-right"
+        autoClose={3000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+      />
+    </>
   );
 }
 

--- a/src/features/admin/components/StatChart/StatChart.jsx
+++ b/src/features/admin/components/StatChart/StatChart.jsx
@@ -55,7 +55,15 @@ function StatsChart() {
             <YAxis
               yAxisId="left"
               orientation="left"
-              tickFormatter={(value) => `${(value / 10000).toLocaleString()}만 원`}
+              tickFormatter={(value) => {
+                if (value >= 100000000) {
+                  return `${(value / 100000000).toLocaleString()}억`;
+                }
+                if (value >= 10000) {
+                  return `${(value / 10000).toLocaleString()}만`;
+                }
+                return value.toLocaleString();
+              }}
             />
 
             {/* 오른쪽 Y축: 주문 건수 */}

--- a/src/features/admin/components/StatChart/StatChart.jsx
+++ b/src/features/admin/components/StatChart/StatChart.jsx
@@ -21,8 +21,20 @@ function StatsChart() {
     const getChartData = async () => {
       try {
         const stats = await fetchRecentStats();
+        const today = new Date();
+        const getDateString = (daysAgo = 0) => {
+          const date = new Date(today);
+          date.setDate(date.getDate() - daysAgo);
+          return date.toISOString().split('T')[0]; // YYYY-MM-DD 형식
+        };
 
-        const formatted = stats.map((item) => ({
+        const targetDates = [getDateString(0), getDateString(1), getDateString(2)];
+
+        const recentThreeDays = stats
+          .filter((item) => targetDates.includes(item.date))
+          .sort((a, b) => new Date(a.date) - new Date(b.date));
+
+        const formatted = recentThreeDays.map((item) => ({
           name: item.date.slice(5),
           sales: item.sales,
           orders: item.orders,

--- a/src/features/admin/components/StatRanking/StatRanking.jsx
+++ b/src/features/admin/components/StatRanking/StatRanking.jsx
@@ -20,7 +20,9 @@ function StatsRanking() {
       try {
         setIsLoading(true);
         const stats = await fetchRankingStats();
-        setData(stats);
+
+        const top5 = stats.sort((a, b) => a.rank - b.rank).slice(0, 5);
+        setData(top5);
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('정보 불러오기 실패:', err);
@@ -46,7 +48,7 @@ function StatsRanking() {
   if (!data || data.length === 0) {
     return (
       <section className={styles.section2}>
-        <h2>오늘의 상품 판매 순위 (1시간 별 기준)</h2>
+        <h2>오늘의 상품 판매 순위 TOP 5 (1시간 별 기준)</h2>
         <p>표시할 데이터가 없습니다.</p>
       </section>
     );
@@ -54,7 +56,7 @@ function StatsRanking() {
 
   return (
     <section className={styles.section2}>
-      <h2>오늘의 상품 판매 순위 (1시간 별 기준)</h2>
+      <h2>오늘의 상품 판매 순위 TOP 5 (1시간 별 기준)</h2>
       <div className={styles.table}>
         <Table columns={columns} data={data} renderRow={renderProductRow} />
       </div>

--- a/src/features/admin/pages/AdminOrder/AdminOrder.jsx
+++ b/src/features/admin/pages/AdminOrder/AdminOrder.jsx
@@ -42,6 +42,19 @@ function AdminOrder() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedOrderId, setSelectedOrderId] = useState(null);
 
+  const fetchOrders = useCallback(async () => {
+    try {
+      const data = await fetchAdminOrders(currentPage - 1, 10);
+      setOrders(data.orders);
+      setTotalPages(data.totalPages);
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('주문 목록 불러오기 실패:', err);
+    }
+
+    fetchOrders();
+  }, [currentPage]);
+
   const handleOpenModal = useCallback((orderId) => {
     setSelectedOrderId(orderId);
     setIsModalOpen(true);
@@ -50,21 +63,12 @@ function AdminOrder() {
   const handleCloseModal = useCallback(() => {
     setIsModalOpen(false);
     setSelectedOrderId(null);
-  }, []);
+    fetchOrders();
+  }, [fetchOrders]);
 
   useEffect(() => {
-    const getOrders = async () => {
-      try {
-        const data = await fetchAdminOrders(currentPage - 1, 10);
-        setOrders(data.orders);
-        setTotalPages(data.totalPages);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.error('주문 목록 불러오기 실패:', err);
-      }
-    };
-    getOrders();
-  }, [currentPage]);
+    fetchOrders();
+  }, [fetchOrders]);
 
   const renderOrderRow = useCallback(
     (row) => (

--- a/src/features/admin/pages/AdminOrder/AdminOrder.jsx
+++ b/src/features/admin/pages/AdminOrder/AdminOrder.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 
 import Pagination from '@/components/Pagination/Pagination';
 import AdminOrderInfoModal from '@/modals/AdminOrderInfoModal/AdminOrderInfoModal';
@@ -64,6 +65,7 @@ function AdminOrder() {
     setIsModalOpen(false);
     setSelectedOrderId(null);
     fetchOrders();
+    toast.dismiss('confirm-toast');
   }, [fetchOrders]);
 
   useEffect(() => {

--- a/src/features/admin/pages/AdminUser/AdminUser.jsx
+++ b/src/features/admin/pages/AdminUser/AdminUser.jsx
@@ -1,4 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
+import {
+  useCallback, //
+  useEffect, //
+  useMemo, //
+  useState, //
+} from 'react';
 
 import Pagination from '@/components/Pagination/Pagination';
 import { fetchAdminUsers, updateUserStatus } from '@/services/adminUserApi';
@@ -27,6 +32,15 @@ function AdminUser() {
   const [users, setUsers] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
+
+  const statusTextMap = useMemo(
+    () => ({
+      ACTIVE: '활성',
+      DORMANT_AUTO: '자동 휴면',
+      DORMANT_MANUAL: '수동 휴면',
+    }),
+    [],
+  );
 
   const handleStatusToggle = useCallback(
     async (id) => {
@@ -76,12 +90,12 @@ function AdminUser() {
         </td>
         <td>
           <button type="button" onClick={() => handleStatusToggle(user.id)}>
-            {user.status === 'ACTIVE' ? '활성' : '휴면'}
+            {statusTextMap[user.status]}
           </button>
         </td>
       </tr>
     ),
-    [handleStatusToggle],
+    [handleStatusToggle, statusTextMap],
   );
 
   return (

--- a/src/features/admin/pages/AdminUser/AdminUser.jsx
+++ b/src/features/admin/pages/AdminUser/AdminUser.jsx
@@ -4,6 +4,7 @@ import {
   useMemo, //
   useState, //
 } from 'react';
+import { toast } from 'react-toastify';
 
 import Pagination from '@/components/Pagination/Pagination';
 import { fetchAdminUsers, updateUserStatus } from '@/services/adminUserApi';
@@ -46,16 +47,14 @@ function AdminUser() {
     async (id) => {
       try {
         await updateUserStatus(id);
-        // eslint-disable-next-line no-alert
-        alert('상태가 변경되었습니다.');
+        toast.success('상태가 변경되었습니다.');
 
         const updated = await fetchAdminUsers(currentPage - 1, 10);
         setUsers(updated.content);
       } catch (err) {
         // eslint-disable-next-line no-console
         console.error('상태 변경 실패:', err);
-        // eslint-disable-next-line no-alert
-        alert('상태 변경 실패');
+        toast.error('상태 변경 실패');
       }
     },
     [currentPage],

--- a/src/modals/AdminOrderInfoModal/AdminOrderInfoModal.jsx
+++ b/src/modals/AdminOrderInfoModal/AdminOrderInfoModal.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 
 import { fetchOrderDetail } from '@/services/adminOrderApi';
 import axiosInstance from '@/services/axiosInstance';
+import useConfirm from '@/utils/useConfirm';
 
 import styles from './AdminOrderInfoModal.module.css';
 
@@ -25,6 +27,8 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [manualStatus, setManualStatus] = useState('PAYMENT_COMPLETED');
+
+  const confirm = useConfirm();
 
   useEffect(() => {
     const handleEscape = (e) => {
@@ -79,18 +83,23 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
     }
     /* eslint-disable operator-linebreak */
 
-    // eslint-disable-next-line no-restricted-globals, no-alert
-    const confirmed = confirm('정말로 주문을 취소하시겠습니까?');
-    if (!confirmed) return;
-    try {
-      setLoading(true);
-      await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, { status: 'CANCELED' });
-      setOrderData((prev) => ({ ...prev, orderStatus: 'CANCELED' }));
-    } catch (err) {
-      setError(err.response?.data?.message || '주문 취소에 실패했습니다.');
-    } finally {
-      setLoading(false);
-    }
+    // eslint-disable-next-line no-restricted-globals
+    confirm('정말로 주문을 취소하시겠습니까?', async () => {
+      try {
+        setLoading(true);
+        await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, {
+          status: 'CANCELED',
+        });
+        setOrderData((prev) => ({ ...prev, orderStatus: 'CANCELED' }));
+        toast.success('주문이 성공적으로 취소되었습니다.');
+      } catch (err) {
+        const errorMessage = err.response?.data?.message || '주문 취소에 실패했습니다.';
+        setError(errorMessage);
+        toast.error(errorMessage);
+      } finally {
+        setLoading(false);
+      }
+    });
   };
 
   const handleStatusChange = async () => {
@@ -103,21 +112,48 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
     } else if (orderData.orderStatus === 'SHIPPING') {
       message = '배송 완료 상태로 변경하시겠습니까?';
     }
-    // eslint-disable-next-line no-restricted-globals, no-alert
-    const confirmed = confirm(message);
-    if (!confirmed) return;
-    const currentIdx = STATUS_SEQUENCE.indexOf(orderData.orderStatus);
-    if (currentIdx === -1 || currentIdx === STATUS_SEQUENCE.length - 1) return;
-    const nextStatus = STATUS_SEQUENCE[currentIdx + 1];
-    try {
-      setLoading(true);
-      await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, { status: nextStatus });
-      setOrderData((prev) => ({ ...prev, orderStatus: nextStatus }));
-    } catch (err) {
-      setError(err.response?.data?.message || '배송 상태 변경에 실패했습니다.');
-    } finally {
-      setLoading(false);
-    }
+
+    confirm(message, async () => {
+      const currentIdx = STATUS_SEQUENCE.indexOf(orderData.orderStatus);
+      if (currentIdx === -1 || currentIdx === STATUS_SEQUENCE.length - 1) return;
+
+      const nextStatus = STATUS_SEQUENCE[currentIdx + 1];
+      try {
+        setLoading(true);
+        await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, {
+          status: nextStatus,
+        });
+        setOrderData((prev) => ({ ...prev, orderStatus: nextStatus }));
+        toast.success('배송 상태가 성공적으로 변경되었습니다.');
+      } catch (err) {
+        const errorMessage = err.response?.data?.message || '배송 상태 변경에 실패했습니다.';
+        setError(errorMessage);
+        toast.error(errorMessage);
+      } finally {
+        setLoading(false);
+      }
+    });
+  };
+
+  const handleManualStatusChange = async () => {
+    if (!orderData) return;
+
+    confirm(`${ORDER_STATUS_MAP[manualStatus]} 상태로 직접 변경하시겠습니까?`, async () => {
+      try {
+        setLoading(true);
+        await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, {
+          status: manualStatus,
+        });
+        setOrderData((prev) => ({ ...prev, orderStatus: manualStatus }));
+        toast.success(`주문 상태가 ${ORDER_STATUS_MAP[manualStatus]}(으)로 변경되었습니다.`);
+      } catch (err) {
+        const errorMessage = err.response?.data?.message || '상태 변경에 실패했습니다.';
+        setError(errorMessage);
+        toast.error(errorMessage);
+      } finally {
+        setLoading(false);
+      }
+    });
   };
 
   return (
@@ -234,25 +270,7 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
                     borderRadius: 4,
                     backgroundColor: '#cfcfcf',
                   }}
-                  onClick={async () => {
-                    if (!orderData) return;
-                    // eslint-disable-next-line no-restricted-globals, no-alert
-                    const confirmed = confirm(
-                      `${ORDER_STATUS_MAP[manualStatus]} 상태로 직접 변경하시겠습니까?`,
-                    );
-                    if (!confirmed) return;
-                    try {
-                      setLoading(true);
-                      await axiosInstance.patch(`/api/admin/orders/${orderId}/status`, {
-                        status: manualStatus,
-                      });
-                      setOrderData((prev) => ({ ...prev, orderStatus: manualStatus }));
-                    } catch (err) {
-                      setError(err.response?.data?.message || '상태 변경에 실패했습니다.');
-                    } finally {
-                      setLoading(false);
-                    }
-                  }}
+                  onClick={handleManualStatusChange}
                   disabled={loading}
                 >
                   상태 직접 변경

--- a/src/modals/AdminProductQuantityModal/AdminProductQuantityModal.jsx
+++ b/src/modals/AdminProductQuantityModal/AdminProductQuantityModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { useEffect, useState } from 'react';
+import { toast } from 'react-toastify';
 
 import { updateProductStock } from '@/services/adminProductApi';
 
@@ -46,8 +47,7 @@ function AdminProductQuantityModal({
   const handleConfirm = async () => {
     try {
       await updateProductStock(productId, newQuantity);
-      // eslint-disable-next-line no-alert
-      alert('상품 수량이 변경되었습니다.');
+      toast.success('상품 수량이 변경되었습니다.');
 
       if (onStatusChanged) {
         await onStatusChanged();
@@ -57,8 +57,7 @@ function AdminProductQuantityModal({
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('상품 수량 변경 실패:', err);
-      // eslint-disable-next-line no-alert
-      alert('상품 수량 변경에 실패했습니다.');
+      toast.error('상품 수량 변경에 실패했습니다.');
     }
   };
 

--- a/src/modals/AdminProductSoldoutModal/AdminProductSoldoutModal.jsx
+++ b/src/modals/AdminProductSoldoutModal/AdminProductSoldoutModal.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
+import { toast } from 'react-toastify';
 
 import { updateProductState } from '@/services/adminProductApi';
 
@@ -38,8 +39,7 @@ function AdminProductQuantityModal({
   const handleConfirm = async () => {
     try {
       await updateProductState(productId);
-      // eslint-disable-next-line no-alert
-      alert('상품 상태가 변경되었습니다.');
+      toast.success('상품 상태가 변경되었습니다.');
 
       if (onStatusChanged) {
         await onStatusChanged();
@@ -49,8 +49,7 @@ function AdminProductQuantityModal({
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('상품 상태 변경 실패:', err);
-      // eslint-disable-next-line no-alert
-      alert('상품 상태 변경 실패');
+      toast.error('상품 상태 변경 실패');
     }
   };
 

--- a/src/utils/useConfirm.jsx
+++ b/src/utils/useConfirm.jsx
@@ -1,0 +1,73 @@
+import { toast } from 'react-toastify';
+
+const useConfirm = () => {
+  const confirm = (message, onConfirm, onCancel) => {
+    toast(
+      ({ closeToast }) => (
+        <div>
+          <p
+            style={{
+              marginBottom: '16px',
+              fontSize: '14px',
+              lineHeight: '1.4',
+              color: 'black',
+            }}
+          >
+            {message}
+          </p>
+          <div style={{ display: 'flex', gap: '8px', justifyContent: 'flex-end' }}>
+            <button
+              type="button"
+              onClick={() => {
+                closeToast();
+                onConfirm?.();
+              }}
+              style={{
+                padding: '8px 16px',
+                backgroundColor: '#ffa948',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '12px',
+                fontWeight: '500',
+              }}
+            >
+              확인
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                closeToast();
+                onCancel?.();
+              }}
+              style={{
+                padding: '8px 16px',
+                backgroundColor: '#9f9f9f',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '12px',
+                fontWeight: '500',
+              }}
+            >
+              취소
+            </button>
+          </div>
+        </div>
+      ),
+      {
+        position: 'top-center',
+        autoClose: false,
+        hideProgressBar: true,
+        closeOnClick: false,
+        closeButton: false,
+      },
+    );
+  };
+
+  return confirm;
+};
+
+export default useConfirm;

--- a/src/utils/useConfirm.jsx
+++ b/src/utils/useConfirm.jsx
@@ -2,7 +2,7 @@ import { toast } from 'react-toastify';
 
 const useConfirm = () => {
   const confirm = (message, onConfirm, onCancel) => {
-    toast(
+    const toastId = toast(
       ({ closeToast }) => (
         <div>
           <p
@@ -63,8 +63,10 @@ const useConfirm = () => {
         hideProgressBar: true,
         closeOnClick: false,
         closeButton: false,
+        toastId: 'confirm-toast',
       },
     );
+    return toastId;
   };
 
   return confirm;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4034,6 +4034,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-toastify@npm:^11.0.5":
+  version: 11.0.5
+  resolution: "react-toastify@npm:11.0.5"
+  dependencies:
+    clsx: "npm:^2.1.1"
+  peerDependencies:
+    react: ^18 || ^19
+    react-dom: ^18 || ^19
+  checksum: 10c0/50f5b81323ebb1957b2efd0963fac24aa1407155d16ab756ffd6d0f42f8af17e796b3958a9fce13e9d1b945d6c3a5a9ebf13529478474d8a2af4bf1dd0db67d2
+  languageName: node
+  linkType: hard
+
 "react@npm:^19.1.0":
   version: 19.1.0
   resolution: "react@npm:19.1.0"
@@ -4460,6 +4472,7 @@ __metadata:
     react-icons: "npm:^5.5.0"
     react-is: "npm:^19.1.0"
     react-router-dom: "npm:^7.6.2"
+    react-toastify: "npm:^11.0.5"
     recharts: "npm:^3.0.2"
     swiper: "npm:^11.2.10"
     vite: "npm:^7.0.0"


### PR DESCRIPTION
## 📌 작업 내용 요약

어떤 작업을 했는지 간략히 설명해주세요.

- 관리자 주문 조회 페이지에서 모달 수정시 테이블 다시 로딩하여 바로 변경
- 관리자 사용자 페이지 활동, 자동 휴면, 수동 휴면 3가지 버전으로 수정
- 관리자 통계 페이지 그래프 단위 수정(억 단위도 추가)
- 관리자 통계 페이지 연속 3일이 아닐 때, 데이터 순서가 고르지 못할 때를 가정하고 조건에 맞게 설정
- 관리자 통계 페이지 판매 순위가 5개가 아닐 때, 데이터 순서가 고르지 못할 때를 가정하고 조건에 맞게 설정

- 토스트 라이브러리 설치 및 연결
  - 일부 alert를 toast로 변경
  - 주문 조회 페이지 안내 문구 스타일 통일
  - 안내 문구 스타일 통일을 위해 utils/useConfirm.jsx로 분리 및 토스트 설정
    -  아니 토스트 css 분리가 안되더라구요.. 그래서 코드 안에 작성함..

- AdminOrderInfoModal.jsx 는 수정이 된것처럼 보이지만, 토스트를 적용하기 위해 분리 하고, 그것에 맞게 적용했을 뿐, 기능과 코드는 사실 그대로 입니닷
---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #103 
- Closes #104 
- Closes #106 
- Closes #107 

- Related to #105

---

## 📎 기타 참고 사항

추가로 리뷰어가 참고해야 할 사항이 있다면 적어주세요.

alert 변경 되지 않는 곳이 있는지, 추가로 디자인도 봐주면 감사하겠습니닷
