### PR TITLE
[Fix] 관리자 페이지의 주문 관리 탭에서 API 호출 무한 반복 현상 개선

### DIFF
--- a/src/features/admin/pages/AdminOrder/AdminOrder.jsx
+++ b/src/features/admin/pages/AdminOrder/AdminOrder.jsx
@@ -52,8 +52,6 @@ function AdminOrder() {
       // eslint-disable-next-line no-console
       console.error('주문 목록 불러오기 실패:', err);
     }
-
-    fetchOrders();
   }, [currentPage]);
 
   const handleOpenModal = useCallback((orderId) => {
@@ -105,6 +103,7 @@ function AdminOrder() {
           isOpen={isModalOpen}
           onClose={handleCloseModal}
           orderId={selectedOrderId}
+          onOrderStatusChange={fetchOrders}
         />
       )}
     </>

--- a/src/modals/AdminOrderInfoModal/AdminOrderInfoModal.jsx
+++ b/src/modals/AdminOrderInfoModal/AdminOrderInfoModal.jsx
@@ -22,7 +22,8 @@ function getOrderStatusText(status) {
 
 const STATUS_SEQUENCE = ['PAYMENT_COMPLETED', 'CREATED', 'SHIPPING', 'COMPLETED'];
 
-function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
+/* eslint-disable-next-line */
+function AdminOrderInfoModal({ isOpen, onClose, orderId, onOrderStatusChange }) {
   const [orderData, setOrderData] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -92,6 +93,7 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
         });
         setOrderData((prev) => ({ ...prev, orderStatus: 'CANCELED' }));
         toast.success('주문이 성공적으로 취소되었습니다.');
+        if (onOrderStatusChange) onOrderStatusChange(); // 주문 상태 변경 콜백 호출
       } catch (err) {
         const errorMessage = err.response?.data?.message || '주문 취소에 실패했습니다.';
         setError(errorMessage);
@@ -125,6 +127,7 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
         });
         setOrderData((prev) => ({ ...prev, orderStatus: nextStatus }));
         toast.success('배송 상태가 성공적으로 변경되었습니다.');
+        if (onOrderStatusChange) onOrderStatusChange(); // 주문 상태 변경 콜백 호출
       } catch (err) {
         const errorMessage = err.response?.data?.message || '배송 상태 변경에 실패했습니다.';
         setError(errorMessage);
@@ -146,6 +149,7 @@ function AdminOrderInfoModal({ isOpen, onClose, orderId }) {
         });
         setOrderData((prev) => ({ ...prev, orderStatus: manualStatus }));
         toast.success(`주문 상태가 ${ORDER_STATUS_MAP[manualStatus]}(으)로 변경되었습니다.`);
+        if (onOrderStatusChange) onOrderStatusChange(); // 주문 상태 변경 콜백 호출
       } catch (err) {
         const errorMessage = err.response?.data?.message || '상태 변경에 실패했습니다.';
         setError(errorMessage);
@@ -329,6 +333,11 @@ AdminOrderInfoModal.propTypes = {
   isOpen: PropTypes.bool.isRequired,
   onClose: PropTypes.func.isRequired,
   orderId: PropTypes.number.isRequired,
+  onOrderStatusChange: PropTypes.func,
+};
+
+AdminOrderInfoModal.defaultProps = {
+  onOrderStatusChange: undefined,
 };
 
 export default AdminOrderInfoModal;


### PR DESCRIPTION
## 📌 작업 내용 요약

- AdminOrder의 fetchOrders 재귀 호출부를 삭제했습니다.
- 모달 내에서 주문 상태가 변경되는 경우에 관리자 페이지가 정상 리렌더링 됩니다.

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #110 