### PR TITLE
[Fix] 회원가입 시 주소 입력 필드 추가

### DIFF
--- a/src/features/auth/components/SignInForm/SignInForm.jsx
+++ b/src/features/auth/components/SignInForm/SignInForm.jsx
@@ -45,7 +45,7 @@ function SignInForm({ onSubmit }) {
           <input
             id="signin-password"
             type="password"
-            placeholder="****"
+            placeholder="********"
             className={styles.signinInput}
             // eslint-disable-next-line react/jsx-props-no-spreading
             {...register('password', { required: true })}

--- a/src/features/auth/components/SignUpForm/SignUpForm.jsx
+++ b/src/features/auth/components/SignUpForm/SignUpForm.jsx
@@ -184,7 +184,7 @@ function SignUpForm({ onSubmit }) {
         <input
           id="signup-password"
           type="password"
-          placeholder="****"
+          placeholder="********"
           className={styles.signupInput}
           {...register('password')} // eslint-disable-line react/jsx-props-no-spreading
           required
@@ -199,7 +199,7 @@ function SignUpForm({ onSubmit }) {
         <input
           id="signup-password-check"
           type="password"
-          placeholder="****"
+          placeholder="********"
           className={styles.signupInput}
           {...register('passwordCheck')} // eslint-disable-line react/jsx-props-no-spreading
           required

--- a/src/features/auth/components/SignUpForm/SignUpForm.jsx
+++ b/src/features/auth/components/SignUpForm/SignUpForm.jsx
@@ -30,6 +30,7 @@ function SignUpForm({ onSubmit }) {
       password: '',
       passwordCheck: '',
       phone: '',
+      address: '',
       agreeTerms: false,
     },
   });
@@ -206,6 +207,21 @@ function SignUpForm({ onSubmit }) {
         />
         {errors.passwordCheck && (
           <div style={{ color: 'red', fontSize: 14 }}>{errors.passwordCheck.message}</div>
+        )}
+      </label>
+      {/* 주소 */}
+      <label htmlFor="signup-address" className={styles.signupLabel}>
+        주소
+        <input
+          id="signup-address"
+          type="text"
+          placeholder="주소를 입력해 주세요"
+          className={styles.signupInput}
+          {...register('address')} // eslint-disable-line react/jsx-props-no-spreading
+          required
+        />
+        {errors.address && (
+          <div style={{ color: 'red', fontSize: 14 }}>{errors.address.message}</div>
         )}
       </label>
       {/* 휴대폰 번호 입력 및 인증 */}

--- a/src/features/auth/pages/SignUp/SignUp.jsx
+++ b/src/features/auth/pages/SignUp/SignUp.jsx
@@ -18,7 +18,7 @@ function SignUp() {
       passwordCheck: data.passwordCheck,
       username: data.username,
       phoneNumber: data.phone,
-      address: '서울특별시 강남구 테헤란로 123',
+      address: data.address,
     };
 
     try {

--- a/src/features/auth/schemas/signInSchema.js
+++ b/src/features/auth/schemas/signInSchema.js
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const signInSchema = z.object({
   email: z.string().email('올바른 이메일 형식이 아닙니다.'),
-  password: z.string().min(4, '비밀번호는 4자 이상이어야 합니다.'),
+  password: z.string().min(8, '비밀번호는 8자 이상이어야 합니다.'),
 });
 
 export default signInSchema;

--- a/src/features/auth/schemas/signUpSchema.js
+++ b/src/features/auth/schemas/signUpSchema.js
@@ -21,6 +21,7 @@ export const signUpSchema = z.object({
       '비밀번호는 영어 소문자, 숫자, 특수문자를 모두 포함해야 합니다.',
     ),
   phone: z.string().regex(/^010\d{8}$/, '휴대폰 번호는 010으로 시작하는 11자리 숫자여야 합니다.'),
+  address: z.string().min(1, '주소를 입력해 주세요.'),
   agreeTerms: z.literal(true, { errorMap: () => ({ message: '이용약관에 동의해 주세요.' }) }),
 });
 

--- a/src/states/authStore.js
+++ b/src/states/authStore.js
@@ -13,7 +13,7 @@ const useAuthStore = create(
           const response = await axiosInstance.post('/api/users/login', { email, password });
           const { accessToken, user } = response.data.data;
           localStorage.setItem('accessToken', accessToken);
-          set({ user });
+          set({ user, loginAt: Date.now() });
           return true;
         } catch (e) {
           return false;
@@ -44,17 +44,29 @@ const useAuthStore = create(
         // localStorage에서 토큰 삭제
         localStorage.removeItem('accessToken');
 
-        // 쿠키 삭제 (과거 날짜로 만료시간 설정하여 삭제)
+        // zustand persist 삭제
+        localStorage.removeItem('auth-storage');
+
+        // 쿠키에서 refreshToken 삭제
         document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
 
-        // 사용자 상태 초기화
-        set({ user: null });
+        // user state 초기화
+        set({ user: null, loginAt: null });
       },
 
       setUser: (user) => set({ user }),
     }),
     {
       name: 'auth-storage',
+      onRehydrateStorage: (state) => (restoredState) => {
+        if (!restoredState) return;
+        const { loginAt } = restoredState;
+        const now = Date.now();
+        const maxAge = 1000 * 60 * 60 * 24; // 1일
+        if (loginAt && now - loginAt > maxAge) {
+          state.logout();
+        }
+      },
     },
   ),
 );


### PR DESCRIPTION
## 📌 작업 내용 요약

- 회원가입 시 주소를 입력받을 수 있는 인풋 필드를 추가했습니다.
- 주소 검증 스키마도 추가했습니다. (현재 별도의 로직은 없으며, 1자 이상)
- 로그인 폼에서 비밀번호 검증을 여전히 4자로 받고 있었던 오류가 있어, 8자로 수정했습니다.
  - 이 PR이 머지되고 나면 4자 짜리 비밀번호로는 로그인이 안 될 것입니다......

로그인 상태가 비정상적으로 유지되고 있는 버그도 제거했습니다!
- 로그아웃 시 localStorage 내에 있는 auth-storage key를 제거하도록 수정했습니다. 이제 오래된 로그인 세션이 자동으로 만료됩니다.
- zustand의 persist 미들웨어에 직접 만료 로직을 추가했습니다.
  - 로그인 시 user와 함께 loginAt을 저장하며, 앱이 시작될 때 loginAt이 1일 이상이면 자동 로그아웃 처리됩니다.

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #122 