### PR TITLE
[Feature] Access token 재발급 구현

### DIFF
--- a/src/services/axiosInstance.js
+++ b/src/services/axiosInstance.js
@@ -5,7 +5,7 @@ const axiosInstance = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true, // 쿠키 인증 쓰나? jwt 토큰 쓰나?
+  withCredentials: true, // 원래대로 복원
 });
 
 axiosInstance.interceptors.request.use(
@@ -19,6 +19,43 @@ axiosInstance.interceptors.request.use(
     return newConfig;
   },
   (error) => Promise.reject(error),
+);
+
+// 401/403 에러 발생 시 자동 토큰 갱신 및 재시도
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    // 401 또는 403 에러이고, 이미 재시도하지 않은 요청이며, refresh 요청이 아닌 경우
+    /* eslint-disable */
+    if (
+      (error.response?.status === 401 || error.response?.status === 403) &&
+      !originalRequest.retried &&
+      !originalRequest.url?.includes('/token/refresh')
+    ) {
+      /* eslint-disable */
+      originalRequest.retried = true;
+
+      try {
+        // eslint-disable-next-line import/no-cycle
+        const { default: useAuthStore } = await import('@/states/authStore');
+        const refreshSuccess = await useAuthStore.getState().refreshAccessToken();
+
+        if (refreshSuccess) {
+          // 새로운 토큰으로 원래 요청 재시도
+          const newToken = localStorage.getItem('accessToken');
+          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+          return axiosInstance(originalRequest);
+        }
+      } catch (refreshError) {
+        // refresh 실패 시 로그인 상태 해제 등은 store에서 처리됨
+        return Promise.reject(refreshError);
+      }
+    }
+
+    return Promise.reject(error);
+  },
 );
 
 export default axiosInstance;

--- a/src/states/authStore.js
+++ b/src/states/authStore.js
@@ -1,7 +1,14 @@
+import axios from 'axios';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import axiosInstance from '@/services/axiosInstance';
+const authAxios = axios.create({
+  baseURL: import.meta.env.VITE_API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  withCredentials: true,
+});
 
 const useAuthStore = create(
   persist(
@@ -10,7 +17,7 @@ const useAuthStore = create(
 
       login: async ({ email, password }) => {
         try {
-          const response = await axiosInstance.post('/api/users/login', { email, password });
+          const response = await authAxios.post('/api/users/login', { email, password });
           const { accessToken, user } = response.data.data;
           localStorage.setItem('accessToken', accessToken);
           set({ user, loginAt: Date.now() });
@@ -22,7 +29,7 @@ const useAuthStore = create(
 
       signup: async (payload) => {
         try {
-          await axiosInstance.post('/api/users/signup', payload);
+          await authAxios.post('/api/users/signup', payload);
           return true;
         } catch (e) {
           return false;
@@ -31,7 +38,7 @@ const useAuthStore = create(
 
       checkEmailDuplicate: async (email) => {
         try {
-          const response = await axiosInstance.get('/api/users/check-email', {
+          const response = await authAxios.get('/api/users/check-email', {
             params: { email },
           });
           return response.data;
@@ -43,19 +50,56 @@ const useAuthStore = create(
       logout: () => {
         // localStorage에서 토큰 삭제
         localStorage.removeItem('accessToken');
-
         // zustand persist 삭제
         localStorage.removeItem('auth-storage');
-
         // 쿠키에서 refreshToken 삭제
         document.cookie = 'refreshToken=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
-
         // user state 초기화
         set({ user: null, loginAt: null });
       },
 
+      // refresh 토큰으로 access 토큰 갱신
+      refreshAccessToken: async () => {
+        try {
+          const response = await authAxios.post('/api/token/refresh', {});
+          const { accessToken } = response.data.data;
+          localStorage.setItem('accessToken', accessToken);
+          return true;
+        } catch (e) {
+          // refresh 토큰이 만료되었거나 유효하지 않음 - 로그아웃 처리
+          const state = useAuthStore.getState();
+          state.logout();
+          return false;
+        }
+      },
+
       setUser: (user) => set({ user }),
+
+      // 앱 진입 시 토큰 검증 및 자동 갱신
+      validateAndRefreshToken: async () => {
+        const accessToken = localStorage.getItem('accessToken');
+
+        if (!accessToken) {
+          // access token이 없으면 refresh 시도
+          return useAuthStore.getState().refreshAccessToken();
+        }
+
+        // access token이 있으면 유효성 검사를 위해 간단한 API 호출
+        try {
+          await authAxios.get('/api/users/me', {
+            headers: { Authorization: `Bearer ${accessToken}` },
+          });
+          return true;
+        } catch (e) {
+          // access token이 만료되었으면 refresh 시도
+          if (e.response?.status === 401) {
+            return useAuthStore.getState().refreshAccessToken();
+          }
+          return false;
+        }
+      },
     }),
+
     {
       name: 'auth-storage',
       onRehydrateStorage: (state) => (restoredState) => {


### PR DESCRIPTION
## 📌 작업 내용 요약

- refresh token을 통해 access token을 재발급하는 로직을 구현했습니다.
- 401 코드를 가정하고 코드를 작성했으나 실제 동작 403으로 떨어지는 것 확인하고 수정했습니다.
- authStore에 axiosIntance의 순환 구조가 생겨 별도의 axios 인스턴스를 정의했습니다.

---

## ✅ 체크리스트

PR을 올리기 전에 아래 항목을 확인했나요?

- [x] 기능 요구사항을 모두 구현했나요?
- [x] 로컬에서 기능을 직접 테스트했나요?
- [x] 코드 컨벤션 및 스타일을 지켰나요?
- [x] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #113 